### PR TITLE
Add option to filter wallpapers by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ BGDIR (defaults to "$HOME/backgrounds") the directory in which to look for
 image files.
 BGSTATE (defaults to "$HOME/.feh-random-background") the state file which holds
 the not-yet-seen images.
+BGEXTENSIONRE (defaults to "png\|jpg\|jpeg\|gif\|tiff") regular expression
+matching the extensions of the files to be used as wallpapers.
 
 # Home manager systemd service
 The file `home-manager-service.nix` is usable with
@@ -24,3 +26,22 @@ work in a NixOS configuration as that uses a slightly different syntax for the
 systemd service files (probably something like
 `<nixpkgs/nixos/modules/services/x11/urxvtd.nix>` should be a good place to
 start looking for the NixOS syntax).
+
+## In flake
+
+To use this in a flake, add this input:
+
+```nix
+feh-random-background = {
+  url = github:KoviRobi/feh-random-background;
+  flake = false;
+};
+```
+
+then you can import the home manager service with:
+
+```nix
+imports = [
+  (inputs.feh-random-background + /home-manager-service.nix)
+];
+```

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ in
 
 stdenvNoCC.mkDerivation {
   pname = "feh-random-background";
-  version = "1.0";
+  version = "1.1";
   src = ./feh-random-background;
 
   phases = [ "installPhase" "patchPhase" ];

--- a/feh-random-background
+++ b/feh-random-background
@@ -2,9 +2,10 @@
 
 BGDIR=${BGDIR:-$HOME/backgrounds}
 BGSTATE=${BGSTATE:-$HOME/.feh-random-background}
+EXTENSIONS=${BGEXTENSIONRE:-"png\|jpg\|jpeg\|gif\|tiff"}
 
 if [ ! -s "$BGSTATE" ]; then
-  find -L "$BGDIR" -type f -print0 | shuf -z > "$BGSTATE"
+  find -L "$BGDIR" -type f -iregex ".*\.\($EXTENSIONS\)" -print0 | shuf -z > "$BGSTATE"
   if [ "$(wc -c < "$BGSTATE")" -eq 0 ]; then
     echo "No background images to choose from"
     exit 1

--- a/home-manager-service.nix
+++ b/home-manager-service.nix
@@ -35,21 +35,34 @@ in
 
       imageDirectory = mkOption {
         type = types.str;
-        example = "%h/backgrounds";
+        default = "${config.home.homeDirectory}/backgrounds";
+        example = "\${config.home.homeDirectory}/backgrounds";
         description = ''
           The directory of images from which a background should be
-          chosen. Should be formatted in a way understood by systemd,
-          e.g., '%h' is the home directory.
+          chosen. Should be formatted in a way understood by systemd.
+          Default to example.
         '';
       };
 
       stateFile = mkOption {
         type = types.str;
-        example = "%h/.feh-random-background-list";
+        default = "${config.home.homeDirectory}/.feh-random-background-list";
+        example = "\${config.home.homeDirectory}/.feh-random-background-list";
         description = ''
           The state file of the not-yet-seen random backgrounds. Should be
-          formatted in a way understood by systemd, e.g., '%h' is the home
-          directory.
+          formatted in a way understood by systemd.
+          Default to example.
+        '';
+      };
+
+      extensionRegEx = mkOption {
+        type = types.str;
+        default = "png\\|jpg\\|jpeg\\|gif\\|tiff";
+        example = "png\\|jpg\\|jpeg\\|gif\\|tiff";
+        description = ''
+          Regular expression matching the extensions of the files
+          to be used as wallpapers.
+          Default to example.
         '';
       };
 
@@ -97,6 +110,7 @@ in
             Environment = [
               "BGDIR=${escapeShellArg cfg.imageDirectory}"
               "BGSTATE=${escapeShellArg cfg.stateFile}"
+              "BGEXTENSIONRE=${escapeShellArg (escape [ "\\" ] cfg.extensionRegEx)}"
             ];
             ExecStart = "${cfg.prog} ${flags}";
             IOSchedulingClass = "idle";


### PR DESCRIPTION
This is useful if the folder has many other files (e.g. is a git versioned folder) to avoid high CPU usage while skipping non-image files.